### PR TITLE
Suppression des produits Géo de la liste blanche

### DIFF
--- a/app/components/standup-deck.js
+++ b/app/components/standup-deck.js
@@ -7,10 +7,7 @@ import { EKMixin, keyUp } from 'ember-keyboard';
 
 const WHITELIST = [
   'api-entreprise',
-  'api-geo',
-  'ban',
   'data.gouv.fr',
-  'geo.data.gouv.fr',
   'openfisca',
   'alpha'
 ];


### PR DESCRIPTION
L'équipe n'est plus présente aux standups, nous allons réfléchir à un nouveau moyen de passer de l'info.